### PR TITLE
Fix the regex for single quoted string

### DIFF
--- a/VimL.tmLanguage
+++ b/VimL.tmLanguage
@@ -261,7 +261,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>'(\\|\'|[^\n'])*'</string>
+					<string>'(\\\\|\\'|[^\n'])*'</string>
 					<key>name</key>
 					<string>string.quoted.single.viml</string>
 				</dict>


### PR DESCRIPTION
The string parsed from `has('mac') || has('macunix')` was `'mac') || has('macunix'`. This fixes the bug and only `'mac'` and `'macunix'` will be parsed as single quoted string.
