### PR TITLE
Make string regexes more accurate

### DIFF
--- a/VimL.tmLanguage
+++ b/VimL.tmLanguage
@@ -249,7 +249,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>"(\\\\|\\"|[^\n"])*"</string>
+					<string>"(\\\\|\\"|\n[^\S\n]*\\|[^\n"])*"</string>
 					<key>name</key>
 					<string>string.quoted.double.viml</string>
 				</dict>
@@ -261,7 +261,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>'(\\\\|\\'|[^\n'])*'</string>
+					<string>'(''|\n[^\S\n]*\\|[^\n'])*'</string>
 					<key>name</key>
 					<string>string.quoted.single.viml</string>
 				</dict>
@@ -273,7 +273,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>/(\\\\|\\/|[^\n/])*/</string>
+					<string>/(\\\\|\\/|\n[^\S\n]*\\|[^\n/])*/</string>
 					<key>name</key>
 					<string>string.regexp.viml</string>
 				</dict>


### PR DESCRIPTION
fixes #3 (single-quoted string escaping), as well adding support for line continuation

The correct escaping rules for single-quoted strings, from [Vim’s help](http://vimdoc.sourceforge.net/htmldoc/eval.html#expr-%27):

> This string is taken as it is. No backslashes are removed or have a special meaning. The only exception is that two quotes stand for one quote.

Additionally, [this Stack Overflow question](http://stackoverflow.com/a/10526992/578288) demonstrates that multi-line strings are supported if the next line’s next non-whitespace character is a backslash. So `\n` should sometimes be allowed in strings.

The regex `[^\S\n]` matches any whitespace character that is not a newline.