### PR TITLE
Fix hexadecimal numbers

### DIFF
--- a/VimL.tmLanguage
+++ b/VimL.tmLanguage
@@ -225,7 +225,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>#[0-9a-f]{6}</string>
+					<string>0x[0-9a-f]+</string>
 					<key>name</key>
 					<string>constant.numeric.hex</string>
 				</dict>


### PR DESCRIPTION
I found odd highlights on GitHub.

<img width="264" alt="2017-02-12 0 51 05" src="https://cloud.githubusercontent.com/assets/823277/22855101/6fb696ac-f0bd-11e6-9239-c90fa664cf8b.png">

Why hexadecimal number is following `#`? I'm not familiar with tmbundle format. So please feel free to reject this if this PR is not correct.

This may fix #7.