### PR TITLE
Add .vimrc files

### DIFF
--- a/VimL.tmLanguage
+++ b/VimL.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>vim</string>
+		<string>.vimrc</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>^(if|while|for|fu|function|try|augroup|aug)</string>


### PR DESCRIPTION
`.vimrc` files are written in VimL, so it would be great if we could add them here.