### PR TITLE
Improve regex syntax pattern

### DIFF
--- a/VimL.tmLanguage
+++ b/VimL.tmLanguage
@@ -274,7 +274,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>/(\\\\|\\/|\n[^\S\n]*\\|[^\n/])*/</string>
+					<string>[gvs]{1}/(\\\\|\\/|\n[^\S\n]*\\|[^\n/])*/</string>
 					<key>name</key>
 					<string>string.regexp.viml</string>
 				</dict>
@@ -286,7 +286,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(set(local|global)?|let|command|filetype|colorscheme|\w*map|\w*a(b|brev)?|syn|exe(c|cute)?|ec(ho|)?|au(tocmd|)?)\b</string>
+					<string>\b(set(local|global)?|let|command|filetype|syntax|colorscheme|\w*map|\w*a(b|brev)?|syn|exe(c|cute)?|ec(ho|)?|au(tocmd|)?)\b</string>
 					<key>name</key>
 					<string>support.function.viml</string>
 				</dict>


### PR DESCRIPTION
Requires regex to be prefixed with either g, v or s
to prevent recognizing file paths as regex.
More info on: https://github.com/sharkdp/bat/issues/1064

Also adds `syntax` keyword. There are still many missing,
but this one occurs very often in vim configurations.