### PR TITLE
Add {g,}vimrc files

### DIFF
--- a/VimL.sublime-syntax
+++ b/VimL.sublime-syntax
@@ -4,6 +4,8 @@
 name: VimL
 file_extensions:
   - vim
+  - vimrc
+  - gvimrc
   - .vimrc
   - .gvimrc
 scope: source.viml


### PR DESCRIPTION
Also highlight the vimrc when it is placed in ~/.vim/vimrc without the dot.