### PR TITLE
Add exrc file names

### DIFF
--- a/VimL.sublime-syntax
+++ b/VimL.sublime-syntax
@@ -8,8 +8,11 @@ file_extensions:
   - gvimrc
   - .vimrc
   - .gvimrc
+  - .exrc
+  - .nvimrc
   - _vimrc
   - _gvimrc
+  - _exrc
 scope: source.viml
 contexts:
   main:


### PR DESCRIPTION
`.exrc` and `_exrc` are supported by both Vim and NeoVim.

`.nvimrc` is NeoVim-specific.
